### PR TITLE
Include git and ssh in pure nix shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -61,6 +61,9 @@ haskell.buildStackProject {
       openjdk
       spark
       nixpkgs.zip
+      # to fetch distributed-closure
+      git
+      openssh
     ];
   extraArgs = ["--extra-lib-dirs=${jvmlibdir}"];
   LD_LIBRARY_PATH = jvmlibdir;


### PR DESCRIPTION
In order to checkout distributed-commands when it hasn't been checked
out yet.

Fixes #13.
